### PR TITLE
Log alert messages to console

### DIFF
--- a/templates/accept_invitation.html
+++ b/templates/accept_invitation.html
@@ -12,9 +12,11 @@
                     
                     {% with messages = get_flashed_messages(with_categories=true) %}
                         {% if messages %}
-                            {% for category, message in messages %}
-                                <div class="alert alert-{{ category }}">{{ message }}</div>
-                            {% endfor %}
+                            <script>
+                                {% for category, message in messages %}
+                                    console.log("{{ category }}:", {{ message|tojson }});
+                                {% endfor %}
+                            </script>
                         {% endif %}
                     {% endwith %}
                     

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -11,9 +11,11 @@
 
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
-    {% for category, message in messages %}
-      <div class="alert alert-{{ category }}">{{ message }}</div>
-    {% endfor %}
+    <script>
+      {% for category, message in messages %}
+        console.log("{{ category }}:", {{ message|tojson }});
+      {% endfor %}
+    </script>
   {% endif %}
 {% endwith %}
 

--- a/templates/invite.html
+++ b/templates/invite.html
@@ -12,9 +12,11 @@
                     
                     {% with messages = get_flashed_messages(with_categories=true) %}
                         {% if messages %}
-                            {% for category, message in messages %}
-                                <div class="alert alert-{{ category }}">{{ message }}</div>
-                            {% endfor %}
+                            <script>
+                                {% for category, message in messages %}
+                                    console.log("{{ category }}:", {{ message|tojson }});
+                                {% endfor %}
+                            </script>
                         {% endif %}
                     {% endwith %}
                     

--- a/templates/invite_user.html
+++ b/templates/invite_user.html
@@ -13,9 +13,11 @@
                 <div class="card-body">
                     {% with messages = get_flashed_messages(with_categories=true) %}
                         {% if messages %}
-                            {% for category, message in messages %}
-                                <div class="alert alert-{{ category }}">{{ message }}</div>
-                            {% endfor %}
+                            <script>
+                                {% for category, message in messages %}
+                                    console.log("{{ category }}:", {{ message|tojson }});
+                                {% endfor %}
+                            </script>
                         {% endif %}
                     {% endwith %}
 

--- a/templates/manage_invitations.html
+++ b/templates/manage_invitations.html
@@ -17,9 +17,11 @@
                     
                     {% with messages = get_flashed_messages(with_categories=true) %}
                         {% if messages %}
-                            {% for category, message in messages %}
-                                <div class="alert alert-{{ category }}">{{ message }}</div>
-                            {% endfor %}
+                            <script>
+                                {% for category, message in messages %}
+                                    console.log("{{ category }}:", {{ message|tojson }});
+                                {% endfor %}
+                            </script>
                         {% endif %}
                     {% endwith %}
                     

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -17,9 +17,11 @@
 
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
-            {% for category, message in messages %}
-                <div class="alert alert-{{ category }}">{{ message }}</div>
-            {% endfor %}
+            <script>
+                {% for category, message in messages %}
+                    console.log("{{ category }}:", {{ message|tojson }});
+                {% endfor %}
+            </script>
         {% endif %}
     {% endwith %}
 


### PR DESCRIPTION
## Summary
- stop rendering alert divs for flash messages
- log flash messages to console on various pages

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68435cbfd7bc832695d5aa628eebd87c