### PR TITLE
Fix leftover lock handling

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -69,7 +69,7 @@
                                             <h4 class="h5">{{ recipe.name }}</h4>
                                             <p class="text-muted"><i>Serves: {{ recipe.servings }}</i></p>
                                     {% if meal_info.status == 'leftover' %}
-                                                
+                                        <p class="text-muted"><em>{{ meal_info.manual_text }}</em></p>
                                     {% endif %}
                                             <input type="hidden" name="recipeid_{{ slot_id }}" value="{{ recipe.id }}">
                                             


### PR DESCRIPTION
## Summary
- ensure leftover assignment skips default-locked slots
- persist leftover lock info in session and mark with lock_type
- treat leftover locks differently when rebuilding meal plans

## Testing
- `python -m py_compile app.py $(find Scripts -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_68436c88ec148326b4ed3ea007b5e55c