### PR TITLE
Fix leftover labeling and add tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -482,7 +482,6 @@ def generate_shopping_list_data(plan_ids: PlanIdsDict) -> ShoppingListDict:
     return shopping_list_by_aisle
 
 
-
 # --- Meal Plan Generation ---
 # Type Aliases for Meal Plan structure
 MealInfoDict = Dict[str, Any] # Holds recipe_id, status, locks etc.
@@ -564,29 +563,30 @@ def assign_leftovers(plan_ids: PlanIdsDict, current_day: str, meal_type: str, le
                 next_day = get_next_day(next_day, days)
                 continue
 
+        leftover_label = f"Leftover from {current_day}'s {meal_type.lower()}"
         plan_ids[next_day][meal_type] = {
-            'recipe_id': current_recipe_id,
-            'status': 'leftover',
-            'manual_text': f"Leftover from {current_day}'s {meal_type}",
-            'locked_by_main': False,
-            'locked_by_user': False
+            "recipe_id": current_recipe_id,
+            "status": "leftover",
+            "manual_text": leftover_label,
+            "locked_by_main": False,
+            "locked_by_user": False,
         }
 
         slot_id = f"{next_day}_{meal_type}"
 
         # Persist leftover lock in DB and update session state
         lock_info = {
-            'recipe_id': current_recipe_id,
-            'manual': False,
-            'default': False,
-            'lock_type': 'leftover',
-            'text': f"Leftover from {current_day}'s {meal_type}"
+            "recipe_id": current_recipe_id,
+            "manual": False,
+            "default": False,
+            "lock_type": "leftover",
+            "text": leftover_label,
         }
         update_persistent_lock(slot_id, lock_info)
 
-        session_locks = session.get('locked_meals', {})
+        session_locks = session.get("locked_meals", {})
         session_locks[slot_id] = lock_info
-        session['locked_meals'] = session_locks
+        session["locked_meals"] = session_locks
         session.modified = True
 
         leftovers -= num_people

--- a/tests/test_leftovers.py
+++ b/tests/test_leftovers.py
@@ -1,0 +1,77 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+from flask_login import login_user
+
+os.environ["EVENTLET_NO_GREENDNS"] = "yes"
+
+# Ensure repository root is on the Python path when running via the pytest CLI
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app import app, db, Recipe, User, Account, generate_meal_plan
+
+
+@pytest.fixture
+def test_app():
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        user = User(email="test@example.com", name="Test")
+        user.password_hash = "x"
+        account = Account(name="TestAccount")
+        account.users.append(user)
+        recipe_dinner = Recipe(name="Dinner1", servings=6, is_dinner=True)
+        recipe_breakfast = Recipe(name="Breakfast1", servings=4, is_breakfast=True)
+        db.session.add_all([user, account, recipe_dinner, recipe_breakfast])
+        db.session.commit()
+        yield user, recipe_dinner
+        db.session.remove()
+        db.drop_all()
+
+
+def _generate(user, locked=None, days=None):
+    if locked is None:
+        locked = {}
+    if days is None:
+        days = ["Monday", "Tuesday", "Wednesday", "Thursday"]
+    with app.test_request_context("/"):
+        login_user(user)
+        return generate_meal_plan(2, locked, days=days)
+
+
+def test_first_meal_leftover_label(test_app):
+    user, recipe = test_app
+    plan = _generate(user)
+    assert plan["Tuesday"]["Dinner"]["status"] == "leftover"
+    assert plan["Tuesday"]["Dinner"]["manual_text"] == "Leftover from Monday's dinner"
+
+
+def test_correct_number_of_leftovers(test_app):
+    user, recipe = test_app
+    plan = _generate(user)
+    leftovers = [
+        plan[day]["Dinner"]
+        for day in ["Tuesday", "Wednesday"]
+        if plan[day]["Dinner"]["status"] == "leftover"
+    ]
+    assert len(leftovers) == 2
+
+
+def test_skip_locked_slot(test_app):
+    user, recipe = test_app
+    locked = {
+        "Tuesday_Dinner": {
+            "recipe_id": recipe.id,
+            "manual": False,
+            "default": False,
+            "lock_type": "user",
+        }
+    }
+    plan = _generate(user, locked=locked)
+    assert plan["Tuesday"]["Dinner"]["status"] == "locked"
+    assert plan["Wednesday"]["Dinner"]["status"] == "leftover"
+    assert plan["Thursday"]["Dinner"]["status"] == "leftover"


### PR DESCRIPTION
## Summary
- label leftover meals as `Leftover from <day>'s <meal type>`
- add pytest suite for leftover functionality

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a7c8a9cc8326b042fe9fa3a1d104